### PR TITLE
Fix discrepancies between logged in user & submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ GET /related-document-information
 
 - `forDecisionType`: (Optional) The type of decision to fetch related documents for.
 - `forEenheid`: (Optional) The organizational unit to fetch related documents for.
-- `forRelatedDecision`: (Optional) A specific decision URI, which will provide the extra info about the related decisbion .
+- `forRelatedDecision`: (Optional) A specific decision URI, which will provide the extra info about the related decision .
 
 Note: If `forRelatedDecision` is not provided, both `forDecisionType` and `forEenheid` are mandatory.
 

--- a/app.js
+++ b/app.js
@@ -7,14 +7,12 @@ import {
   prepareQuery,
   isCKB,
   isGemeente,
+  isDecisionTypeFromCKB,
   ckbDecisionTypeToRelatedType,
   prepareCKBSearchQuery
 } from './query-utils';
 import { fromEenheid } from './middlewares.js';
 import { invalidDecisionTypeError, sendTurtleResponse } from './utils.js';
-import {
-  crossReferenceMappingsGemeente_CKB_EB
-} from './config/cross-reference-mappings';
 
 const BYPASS_HOP_CENTRAAL_BESTUUR = process.env.BYPASS_HOP_CENTRAAL_BESTUUR || false;
 
@@ -81,11 +79,7 @@ app.get('/document-information', async function (req, res) {
     const eenheid = await getEenheidForDecision(forDecision);
 
     const isLoggedInAsGemeente = await isGemeente(req.fromEenheid);
-    // Trick: if the decision type is both in the keys AND in thevalues of `crossReferenceMappingsGemeente_CKB_EB` ,
-    // then it has to be a CKB decision type.
-    const isSubmissionSentByCKB =
-      Object.values(crossReferenceMappingsGemeente_CKB_EB).some(e => e == forDecisionType)
-      && crossReferenceMappingsGemeente_CKB_EB[forDecisionType];
+    const isSubmissionSentByCKB = isDecisionTypeFromCKB(forDecisionType);
 
     let ckbUri;
     let decisionTypeData;

--- a/query-utils.js
+++ b/query-utils.js
@@ -59,20 +59,19 @@ export async function getEenheidForDecision( decisionUri ) {
 
   const result = (await querySudo(queryStr))?.results?.bindings || [];
   return result[0] ? result[0].eenheid.value : null;
-
 }
 
 export function getRelatedDecisionType( decisionType, hasCKB ) {
   // Mapping differs for some documents only if bestuurseenheid has CKB. 
   if (hasCKB) {
     return {
-      ckbSpecificDdecisionType: true,
+      ckbSpecificDecisionType: true,
       decisionType: crossReferenceMappingsGemeente_CKB_EB[decisionType]
     };
   }
   else {
     return {
-      ckbSpecificDdecisionType: false,
+      ckbSpecificDecisionType: false,
       decisionType: crossReferenceMappingsGemeente_EB[decisionType]
     };
   }
@@ -85,7 +84,7 @@ export function ckbDecisionTypeToRelatedType(decisionType) {
 export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData, forDecision }) {
   let query;
 
-  if (decisionTypeData?.ckbSpecificDdecisionType) {
+  if (decisionTypeData?.ckbSpecificDecisionType) {
     query = `
       PREFIX dcterms: <http://purl.org/dc/terms/>
       PREFIX prov: <http://www.w3.org/ns/prov#>
@@ -346,6 +345,15 @@ export async function isCKB(eenheidUri) {
   const queryStr = `
     ASK {
       ${sparqlEscapeUri(eenheidUri)} a <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst> .
+    }`
+
+  return (await querySudo(queryStr)).boolean;
+}
+
+export async function isDecidableByCKB(forDecisionType) {
+  const queryStr = `
+    ASK {
+      ${sparqlEscapeUri(forDecisionType)} <http://lblod.data.gift/vocabularies/besluit/decidableBy> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> .
     }`
 
   return (await querySudo(queryStr)).boolean;

--- a/query-utils.js
+++ b/query-utils.js
@@ -350,10 +350,13 @@ export async function isCKB(eenheidUri) {
   return (await querySudo(queryStr)).boolean;
 }
 
-export async function isDecidableByCKB(forDecisionType) {
+export async function isGemeente(eenheidUri) {
   const queryStr = `
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    PREFIX org: <http://www.w3.org/ns/org#>
+
     ASK {
-      ${sparqlEscapeUri(forDecisionType)} <http://lblod.data.gift/vocabularies/besluit/decidableBy> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> .
+      ${sparqlEscapeUri(eenheidUri)} besluit:classificatie|org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> .
     }`
 
   return (await querySudo(queryStr)).boolean;

--- a/query-utils.js
+++ b/query-utils.js
@@ -81,6 +81,13 @@ export function ckbDecisionTypeToRelatedType(decisionType) {
   return crossReferenceMappingsGemeente_CKB_EB[decisionType];
 }
 
+export function isDecisionTypeFromCKB(decisionType) {
+  // Trick: if the decision type is both in the keys AND in thevalues of `crossReferenceMappingsGemeente_CKB_EB`,
+  // then it has to be a CKB decision type.
+  return Object.values(crossReferenceMappingsGemeente_CKB_EB).some(e => e == decisionType)
+    && crossReferenceMappingsGemeente_CKB_EB[decisionType];
+}
+
 export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData, forDecision }) {
   let query;
 


### PR DESCRIPTION
# Context

In some apps, for example `app-worship-decisions-database`, the logged-in user can be different from the bestuur that created the submission we're trying to get info from.

Ex: a Gemeente can be opening a submission sent by a CKB.

In this case, the check `isCKB`, based on the logged in user only, is failing to help the service follow the correct path. I added an extra check on the type of bestuuren that are allowed to decide on the type of submissions that we request extra information on.

# How to test

I'll write down the path I took, maybe the person checking out the PR can try a similar-but-slightly-different one for extra coverage!

- In Loket
  - Log in as ` Kerkfabriek St.-Lambertus van Grobbendonk`, submit a new `Jaarrekening`
  - Log in as `CKB Grobbendonk`, submit a new `Jaarrekeningen van de besturen van de eredienst` referencing the previous document
  - Log in as `Gemeente Grobbendonk`, submit a new `Advies bij jaarrekening eredienstbestuur`
- Let it flow through producers consumers
- In WorshipDB
  - Log in as `Gemeente Grobbendonk` and open the two submissions that pop. `Jaarrekeningen van de besturen van de eredienst` was failing before that fix

If it helps and the code looks OK to you, we could also merge that PR, release and test directly on DEV. It's a bit easier setup-wise. 