### PR TITLE
Fix CKB behaviors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,41 @@ Service to retrieve related document information for decisions, enabling users t
 
 ## Endpoints
 
-### GET /related-document-information
+### GET /search-documents
 
-This endpoint fetches related document information based on the provided query parameters.
+This endpoint looks for documents based on the provided query parameters.
 
 #### Request
 
 ```
-GET /related-document-information
+GET /search-documents
+```
+
+#### Query Parameters
+
+- `forDecisionType`: (Optional) The type of decision to fetch related documents for.
+- `forEenheid`: (Optional) The organizational unit to fetch related documents for.
+
+Note: It will only work when the call goes through mu-identifier.
+
+#### Usage Example
+```
+GET /search-documents?forDecisionType=someType&forEenheid=someEenheid
+```
+
+#### Response
+- Status 200: Returns the related document information in Turtle format.
+- Status 400: Returns an error message if required query parameters or headers are missing.
+- Status 500: Returns an error message if an internal server error occurs.
+
+### GET /document-information
+
+This endpoint fetches document information based on the provided query parameters.
+
+#### Request
+
+```
+GET /document-information
 ```
 
 #### Query Parameters
@@ -24,26 +51,23 @@ Note: If `forRelatedDecision` is not provided, both `forDecisionType` and `forEe
 
 Note: It will only work when the call goes through mu-identifier.
 
-#### Enviroment variables
-
-- `WORSHIP_DECISIONS_BASE_URL`: Base url where more information may be found about the related decision. It's a link to the connectected submission.
-      Defaults to "https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/"
-- `SCOPE_SUBMISSIONS_TO_ONE_GRAPH`: Force the submissions to come from the same graph. Mainly used for applications with a lot of graphs, to avoid query timeouts.
-      Defaults to "false"
-
 #### Response
 
 - Status 200: Returns the related document information in Turtle format.
 - Status 400: Returns an error message if required query parameters or headers are missing.
 - Status 500: Returns an error message if an internal server error occurs.
 
-## Usage Example
+#### Usage Example
 ```
-GET /related-document-information?forDecisionType=someType&forEenheid=someEenheid
+GET /document-information?forDecisionType=someType&forEenheid=someEenheid
 ```
-### Response
 
-Turtle formatted response with related document information.
+## Enviroment variables
+
+- `WORSHIP_DECISIONS_BASE_URL`: Base url where more information may be found about the related decision. It's a link to the connectected submission.
+      Defaults to "https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/"
+- `SCOPE_SUBMISSIONS_TO_ONE_GRAPH`: Force the submissions to come from the same graph. Mainly used for applications with a lot of graphs, to avoid query timeouts.
+      Defaults to "false"
 
 ## Development Notes
 The service checks if the organizational unit is related to a Centraal Bestuur.

--- a/config/cross-reference-mappings.js
+++ b/config/cross-reference-mappings.js
@@ -82,15 +82,4 @@ export const crossReferenceMappingsGemeente_CKB_EB = {
   "https://data.vlaanderen.be/id/concept/BesluitDocumentType/2c9ada23-1229-4c7e-a53e-acddc9014e4e":
     // Meerjarenplan(aanpassing)
     "https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f",
-
-  // Schorsing beslissing eredienstbesturen
-  "https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827":
-    // Notulen
-    "https://data.vlaanderen.be/id/concept/BesluitDocumentType/8e791b27-7600-4577-b24e-c7c29e0eb773",
-
-  // Opvragen bijkomende inlichtingen eredienstbesturen (met als gevolg stuiting termijn)
-  "https://data.vlaanderen.be/id/concept/BesluitDocumentType/24743b26-e0fb-4c14-8c82-5cd271289b0e":
-    // Notulen
-    "https://data.vlaanderen.be/id/concept/BesluitDocumentType/8e791b27-7600-4577-b24e-c7c29e0eb773",
 }
-


### PR DESCRIPTION
# Context 

DL-6336 & DL-6335

1. CKBs can be referenced by a Gemeente/Province for two types. In those case, we don't want to enforce the link Gemeente -> CKB -> EB even if the creator of the submission is the CKB
2. The triples returned when asking for info on a bundled submission were about the child submission submitted by the EB instead of being about the bundled submission itself, causing stange behaviors in the frontend such as submissions having multiple sent dates and links not being correct.

# Testing

## DL-6336

To be tested together with https://github.com/lblod/frontend-loket/pull/421

- Make sure you have created ‘Notulen’ submissions in the EB or CB you want to use.
- With a municipality/province create a submission ‘Schorsing beslissing eredienstbesturen’.

##  DL-6335

- Prepare a submission with (central) worship service to be used by the municipality.
- Select a worship service that already has made a submission before (or make one & wait until the following day).
- In a municipality start a submission that has the component to cross-reference EB-CB documents. It should show correct dates and links.