### PR TITLE
Some improvements

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,6 @@ import {
   prepareQuery,
   isCKB,
   isGemeente,
-  isDecisionTypeFromCKB,
   isCkbRelevantForDecisionType,
   ckbDecisionTypeToRelatedType,
   prepareCKBSearchQuery
@@ -87,7 +86,6 @@ app.get('/document-information', async function (req, res) {
     const eenheid = await getEenheidForDecision(forDecision);
 
     const isLoggedInAsGemeente = await isGemeente(req.fromEenheid);
-    const isSubmissionSentByCKB = isDecisionTypeFromCKB(forDecisionType);
 
     let ckbUri;
     let decisionTypeData;
@@ -99,7 +97,7 @@ app.get('/document-information', async function (req, res) {
       We exclude the case where, when logged in as a municipality, the user opens a submission that the municipality can
       view BUT that has been submitted by a different administrative units (in practice, it will always be a CKB).
     */
-    if (isLoggedInAsGemeente && !isSubmissionSentByCKB) {
+    if (isLoggedInAsGemeente) {
         if (forDecision && !forDecisionType) {
         return res.status(400).json({
           error: `Missing required query parameters. Both "forDecision" and "forDecisionType" are required.`

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ import {
   prepareQuery,
   isCKB,
   isGemeente,
+  isDecisionTypeFromCKB,
   isCkbRelevantForDecisionType,
   ckbDecisionTypeToRelatedType,
   prepareCKBSearchQuery
@@ -86,6 +87,7 @@ app.get('/document-information', async function (req, res) {
     const eenheid = await getEenheidForDecision(forDecision);
 
     const isLoggedInAsGemeente = await isGemeente(req.fromEenheid);
+    const isSubmissionSentByCKB = isDecisionTypeFromCKB(forDecisionType);
 
     let ckbUri;
     let decisionTypeData;
@@ -97,7 +99,7 @@ app.get('/document-information', async function (req, res) {
       We exclude the case where, when logged in as a municipality, the user opens a submission that the municipality can
       view BUT that has been submitted by a different administrative units (in practice, it will always be a CKB).
     */
-    if (isLoggedInAsGemeente) {
+    if (isLoggedInAsGemeente && !isSubmissionSentByCKB) {
         if (forDecision && !forDecisionType) {
         return res.status(400).json({
           error: `Missing required query parameters. Both "forDecision" and "forDecisionType" are required.`

--- a/query-utils.js
+++ b/query-utils.js
@@ -94,13 +94,6 @@ export function ckbDecisionTypeToRelatedType(decisionType) {
   return crossReferenceMappingsGemeente_CKB_EB[decisionType];
 }
 
-export function isDecisionTypeFromCKB(decisionType) {
-  // Trick: if the decision type is both in the keys AND in thevalues of `crossReferenceMappingsGemeente_CKB_EB`,
-  // then it has to be a CKB decision type.
-  return Object.values(crossReferenceMappingsGemeente_CKB_EB).some(e => e == decisionType)
-    && crossReferenceMappingsGemeente_CKB_EB[decisionType];
-}
-
 export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData, forDecision }) {
   let query;
 

--- a/query-utils.js
+++ b/query-utils.js
@@ -336,7 +336,6 @@ export function prepareCKBSearchQuery({ fromEenheid, forEenheid, decisionType })
     } WHERE {
       VALUES ?forEenheid {
         ${sparqlEscapeUri(forEenheid)}
-        <http://data.lblod.info/id/besturenVanDeEredienst/5a04126b0c2c7b04bf3e01f69fffa936>
       }
 
       VALUES ?fromEenheid {

--- a/query-utils.js
+++ b/query-utils.js
@@ -94,6 +94,13 @@ export function ckbDecisionTypeToRelatedType(decisionType) {
   return crossReferenceMappingsGemeente_CKB_EB[decisionType];
 }
 
+export function isDecisionTypeFromCKB(decisionType) {
+  // Trick: if the decision type is both in the keys AND in thevalues of `crossReferenceMappingsGemeente_CKB_EB`,
+  // then it has to be a CKB decision type.
+  return Object.values(crossReferenceMappingsGemeente_CKB_EB).some(e => e == decisionType)
+    && crossReferenceMappingsGemeente_CKB_EB[decisionType];
+}
+
 export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData, forDecision }) {
   let query;
 


### PR DESCRIPTION
I found some weird things that can be improved:

* There is a hardcoded URI hidden in a query. This URI belongs to OLV van Aalst in Nieuwerkerken. I assume this was left in there while testing the code.
* The function 'isDecisionTypeFromCKB' always evaluates to 'false', given the configuration. We get correct results, thus we can remove this function and its calls. Checking if the decision types is from a CKB is also indirectly checked by the following lines. Line https://github.com/lblod/worship-decisions-cross-reference-service/blob/a5a61e72e5d4f82d7675da629d6dbdac3af17de1/app.js#L122 will evaluate to 'undefined' if it cannot find the type and so we end up in the same situation as if the type was not sent in by the CKB in the first place.