### PR TITLE
Ensure to check for active CKB

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 import { app } from 'mu';
 import { querySudo } from '@lblod/mu-auth-sudo';
 import {
-  getRelatedToCKB,
+  getRelatedToActiveCKB,
   getEenheidForDecision,
   getRelatedDecisionType,
   prepareQuery,
@@ -52,7 +52,7 @@ app.get('/search-documents', async function (req, res) {
 
       if (isCkbRelevant) {
         // Figure out whether the administrative unit is related to CKB
-        ckbUri = await getRelatedToCKB(forEenheid);
+        ckbUri = await getRelatedToActiveCKB(forEenheid);
 
         if (BYPASS_HOP_CENTRAAL_BESTUUR) {
           console.warn(`Skipping extra hop centraal bestuur. This should only be used in development mode.`);
@@ -111,7 +111,7 @@ app.get('/document-information', async function (req, res) {
 
       if (isCkbRelevant) {
         // Figure out whether the administrative unit is related to a CKB or is a CKB itself
-        ckbUri = await isCKB(eenheid) ? eenheid : await getRelatedToCKB(eenheid);
+        ckbUri = await isCKB(eenheid) ? eenheid : await getRelatedToActiveCKB(eenheid);
 
         if (BYPASS_HOP_CENTRAAL_BESTUUR) {
           console.warn(`Skipping extra hop centraal bestuur. This should only be used in development mode.`);

--- a/query-utils.js
+++ b/query-utils.js
@@ -36,11 +36,12 @@ export async function bestuurseenheidForSession( sessionUri ) {
   }
 }
 
-export async function getRelatedToCKB( eenheidUri ) {
+export async function getRelatedToActiveCKB( eenheidUri ) {
   const queryStr = `
     SELECT DISTINCT ?ckb WHERE {
       ?ckb <http://www.w3.org/ns/org#hasSubOrganization> ${sparqlEscapeUri(eenheidUri)};
-        a <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>.
+        a <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
     }
   `;
   const result = (await querySudo(queryStr))?.results?.bindings || [];


### PR DESCRIPTION
# Context

[DL-6636]

Users found an edge case where there is a CKB between a worship service and a municipality BUT that CKB is inactive, causing the municipality not to be able to reference documents from the worship service.

This PR ensures we check for active CKBs, not only CKBs, in between municipalities and worship services.

# Test instructions

1. Checkout this PR locally and add the following to the `docker-compose.override.yml` file of Loket:
```
  worship-decisions-cross-reference:
    environment:
      NODE_ENV: "development"
    volumes:
      - /path/to/service/worship-decisions-cross-reference-service/:/app/
```
2. Either get a prod backup or create a new Jaarrekening for `Kerkfabriek Alle Heiligen van Zwalm (Nederzwalm-Hermelgem)`
3. Log in as `Gemeente Zwalm`, create an `Advies bij jaarrekening eredienstbestuur`. You should be able to find documents to reference.

# Bump and deploy notes

Once this PR is merged, tagged and released, the service will have to be bumped in the following applications:
- app-digitaal-loket
- app-toezicht-abb
- app-meldingsplichtige-api
- app-worship-decisions-database