### PR TITLE
'Fix' virtuoso performance issue -> see deeper comment

### DIFF
--- a/query-utils.js
+++ b/query-utils.js
@@ -167,10 +167,12 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
                 `: ''
             }
 
-            ?betrokkenBestuur <http://www.w3.org/ns/org#organization> ?eredienst.
-            ?eenheid <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur.
+            FILTER EXISTS {
+              ?betrokkenBestuur <http://www.w3.org/ns/org#organization> ?eredienst.
+              ?eenheid <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur.
 
-            ?ckb <http://www.w3.org/ns/org#hasSubOrganization> ?eredienst.
+              ?ckb <http://www.w3.org/ns/org#hasSubOrganization> ?eredienst.
+            }
 
             ?eredienst skos:prefLabel ?eredienstLabel.
             ?ckb skos:prefLabel ?ckbLabel.


### PR DESCRIPTION
For some reasons, we were hitting performance bottlencks for the case `ckbSpecificDecisionType` .

The triples previously NOT wrapped in the `FILTER EXISTS` are indeed only for checking whether there is a relation between the provided ckb, eredienstBestuur and eenheid.
Wrapping these in a `FILTER EXISTS`, magically fixes performance....
See: https://binnenland.atlassian.net/browse/DL-6782