### PR TITLE
DL-7170: make sudo query usage configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.8.0
+FROM semtech/mu-javascript-template:1.9.1
 LABEL maintainer=info@redpenci

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ GET /document-information?forDecisionType=someType&forEenheid=someEenheid
       Defaults to "https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/"
 - `SCOPE_SUBMISSIONS_TO_ONE_GRAPH`: Force the submissions to come from the same graph. Mainly used for applications with a lot of graphs, to avoid query timeouts.
       Defaults to "false"
-- `USE_SUDO_QUERIES`: Whether or not the service uses sudo queries when querying the database. Defaults to `true`.
+- `USE_SUDO_QUERIES`: Whether or not the service uses sudo queries when querying the database. Defaults to `true`. Note: the session information will always be queried using a sudo query, regardless of this setting.
+
+You'll also need to set `ALLOW_MU_AUTH_SUDO` to `true`, as this service uses sudo queries.
 
 ## Development Notes
 The service checks if the organizational unit is related to a Centraal Bestuur.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ GET /document-information?forDecisionType=someType&forEenheid=someEenheid
       Defaults to "https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/"
 - `SCOPE_SUBMISSIONS_TO_ONE_GRAPH`: Force the submissions to come from the same graph. Mainly used for applications with a lot of graphs, to avoid query timeouts.
       Defaults to "false"
+- `USE_SUDO_QUERIES`: Whether or not the service uses sudo queries when querying the database. Defaults to `true`.
 
 ## Development Notes
 The service checks if the organizational unit is related to a Centraal Bestuur.

--- a/app.js
+++ b/app.js
@@ -1,5 +1,4 @@
 import { app } from 'mu';
-import { querySudo } from '@lblod/mu-auth-sudo';
 import {
   getRelatedToActiveCKB,
   getEenheidForDecision,
@@ -10,7 +9,8 @@ import {
   isDecisionTypeFromCKB,
   isCkbRelevantForDecisionType,
   ckbDecisionTypeToRelatedType,
-  prepareCKBSearchQuery
+  prepareCKBSearchQuery,
+  queryDatabase
 } from './query-utils';
 import { fromEenheid } from './middlewares.js';
 import { invalidDecisionTypeError, sendTurtleResponse } from './utils.js';
@@ -72,7 +72,7 @@ app.get('/search-documents', async function (req, res) {
 
     // execute query
     // TODO: Here we could add a hook to connect to vendor-API if we need to.
-    const triples = (await querySudo(query))?.results?.bindings || [];
+    const triples = (await queryDatabase(query))?.results?.bindings || [];
     return sendTurtleResponse(res, triples);
   } catch (error) {
     console.log(error);
@@ -126,7 +126,7 @@ app.get('/document-information', async function (req, res) {
 
     // execute query
     // TODO: Here we could add a hook to connect to vendor-API if we need to.
-    const triples = (await querySudo(query))?.results?.bindings || [];
+    const triples = (await queryDatabase(query))?.results?.bindings || [];
     return sendTurtleResponse(res, triples);
   } catch (error) {
     return res.status(500).json({ error: error.message });

--- a/app.js
+++ b/app.js
@@ -11,11 +11,10 @@ import {
   ckbDecisionTypeToRelatedType,
   prepareCKBSearchQuery,
   queryDatabase
-} from './query-utils';
+} from './query-utils.js';
 import { fromEenheid } from './middlewares.js';
 import { invalidDecisionTypeError, sendTurtleResponse } from './utils.js';
-
-const BYPASS_HOP_CENTRAAL_BESTUUR = process.env.BYPASS_HOP_CENTRAAL_BESTUUR || false;
+import ENV from './env.js';
 
 app.use(fromEenheid);
 
@@ -54,7 +53,7 @@ app.get('/search-documents', async function (req, res) {
         // Figure out whether the administrative unit is related to CKB
         ckbUri = await getRelatedToActiveCKB(forEenheid);
 
-        if (BYPASS_HOP_CENTRAAL_BESTUUR) {
+        if (ENV.BYPASS_HOP_CENTRAAL_BESTUUR) {
           console.warn(`Skipping extra hop centraal bestuur. This should only be used in development mode.`);
           ckbUri = null;
         }

--- a/env.js
+++ b/env.js
@@ -1,5 +1,4 @@
-import * as env from 'env-var';
-
+import env from 'env-var';
 const ENV = {
   BYPASS_HOP_CENTRAAL_BESTUUR: env.get('BYPASS_HOP_CENTRAAL_BESTUUR').default('false').asBool(),
   WORSHIP_DECISIONS_BASE_URL: env.get('WORSHIP_DECISIONS_BASE_URL').default('https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/').asString(),

--- a/env.js
+++ b/env.js
@@ -3,7 +3,8 @@ import * as env from 'env-var';
 const ENV = {
   BYPASS_HOP_CENTRAAL_BESTUUR: env.get('BYPASS_HOP_CENTRAAL_BESTUUR').default('false').asBool(),
   WORSHIP_DECISIONS_BASE_URL: env.get('WORSHIP_DECISIONS_BASE_URL').default('https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/').asString(),
-  SCOPE_SUBMISSIONS_TO_ONE_GRAPH: env.get('SCOPE_SUBMISSIONS_TO_ONE_GRAPH').default('false').asBool()
+  SCOPE_SUBMISSIONS_TO_ONE_GRAPH: env.get('SCOPE_SUBMISSIONS_TO_ONE_GRAPH').default('false').asBool(),
+  USE_SUDO_QUERIES: env.get('USE_SUDO_QUERIES').default('true').asBool(),
 }
 
 export default ENV;

--- a/env.js
+++ b/env.js
@@ -1,0 +1,9 @@
+import * as env from 'env-var';
+
+const ENV = {
+  BYPASS_HOP_CENTRAAL_BESTUUR: env.get('BYPASS_HOP_CENTRAAL_BESTUUR').default('false').asBool(),
+  WORSHIP_DECISIONS_BASE_URL: env.get('WORSHIP_DECISIONS_BASE_URL').default('https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/').asString(),
+  SCOPE_SUBMISSIONS_TO_ONE_GRAPH: env.get('SCOPE_SUBMISSIONS_TO_ONE_GRAPH').default('false').asBool()
+}
+
+export default ENV;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "0.4.8",
       "license": "MIT",
       "dependencies": {
-        "body-parser": "1.19.0"
-      },
-      "devDependencies": {
+        "body-parser": "1.19.0",
         "env-var": "^7.5.0"
       }
     },
@@ -82,7 +80,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/env-var/-/env-var-7.5.0.tgz",
       "integrity": "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "body-parser": "1.19.0"
+      },
+      "devDependencies": {
+        "env-var": "^7.5.0"
       }
     },
     "node_modules/body-parser": {
@@ -74,6 +77,16 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/env-var": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/env-var/-/env-var-7.5.0.tgz",
+      "integrity": "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/http-errors": {
       "version": "1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,82 +9,7 @@
       "version": "0.4.8",
       "license": "MIT",
       "dependencies": {
-        "@lblod/mu-auth-sudo": "0.6.1",
         "body-parser": "1.19.0"
-      }
-    },
-    "node_modules/@lblod/mu-auth-sudo": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@lblod/mu-auth-sudo/-/mu-auth-sudo-0.6.1.tgz",
-      "integrity": "sha512-fGlx6kAxz0IS5gcnOQshCvjBQMIu1a8fC0c/5pq1/phGHdg0z1kiJXLuL0TSfpojxTZPTBmmIhLv60FNBC36PA==",
-      "license": "MIT",
-      "dependencies": {
-        "env-var": "^7.0.1",
-        "sparql-client-2": "git+https://github.com/erikap/node-sparql-client.git"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/body-parser": {
@@ -117,24 +42,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -142,24 +49,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/debug": {
@@ -171,21 +60,6 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/denodeify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
-      "integrity": "sha512-KNTihKNmQENUZeKu5fzfpzRqR5S2VMp4gl9RFHiWzj9DfvYQPMJ6XHKNaQxaGCXwPk6y9yme3aUoaiAe+KX+vg==",
-      "license": "MIT"
-    },
     "node_modules/depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -195,112 +69,11 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
-    },
-    "node_modules/env-var": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/env-var/-/env-var-7.5.0.tgz",
-      "integrity": "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "license": "MIT"
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/http-errors": {
       "version": "1.7.2",
@@ -316,21 +89,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/iconv-lite": {
@@ -350,63 +108,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
       "license": "ISC"
-    },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "license": "MIT"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
-    },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
-    },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -444,15 +145,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -463,37 +155,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
-    },
-    "node_modules/promise-nodeify": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/promise-nodeify/-/promise-nodeify-0.1.0.tgz",
-      "integrity": "sha512-DfFqhZ0M1bZwLighBvNHWxTy/LRvmZfbWE7/NKdPf1cUQzXzgzOAmp8VMCxcjZyoAZHYH+b10xeB5AkviOh0gw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10",
-        "npm": ">=1.3.7"
-      }
-    },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "license": "MIT"
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -520,67 +181,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -592,45 +192,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
       "license": "ISC"
-    },
-    "node_modules/sparql-client-2": {
-      "version": "0.6.2",
-      "resolved": "git+ssh://git@github.com/erikap/node-sparql-client.git#b7bb3ac76a3708ca2c6d4a04af226df3c71ce95d",
-      "license": "MIT",
-      "dependencies": {
-        "denodeify": "^1.2.1",
-        "lodash": "^4.0.1",
-        "promise-nodeify": "^0.1.0",
-        "request": "^2.40.0"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -649,37 +210,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -701,39 +231,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "worship-decisions-cross-reference-service",
   "version": "0.4.8",
   "description": "Microservice allowing to fetch related documents to a provided Decision/DocumentType.",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lblod/submissions-cross-reference-service.git"

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "devDependencies": {
+    "env-var": "^7.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,10 @@
   "author": "redpencil.io",
   "license": "MIT",
   "dependencies": {
-    "body-parser": "1.19.0"
+    "body-parser": "1.19.0",
+    "env-var": "^7.5.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "devDependencies": {
-    "env-var": "^7.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "redpencil.io",
   "license": "MIT",
   "dependencies": {
-    "@lblod/mu-auth-sudo": "0.6.1",
     "body-parser": "1.19.0"
   },
   "scripts": {

--- a/query-utils.js
+++ b/query-utils.js
@@ -2,12 +2,8 @@ import { sparqlEscapeUri, query } from 'mu';
 import {
   crossReferenceMappingsGemeente_EB,
   crossReferenceMappingsGemeente_CKB_EB
-} from './config/cross-reference-mappings';
-
-const WORSHIP_DECISIONS_BASE_URL = process.env.WORSHIP_DECISIONS_BASE_URL
-  || "https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/";
-
-const SCOPE_SUBMISSIONS_TO_ONE_GRAPH = process.env.SCOPE_SUBMISSIONS_TO_ONE_GRAPH == 'true' ? true : false;
+} from './config/cross-reference-mappings.js';
+import ENV from './env.js';
 
 export async function bestuurseenheidForSession(sessionUri) {
   const queryStr = `
@@ -124,7 +120,7 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
       }
       WHERE {
         {
-          SELECT DISTINCT ?childDecision ?childDecisionTypeLabel ?ckbLabel ?what ?eredienst ?eredienstLabel ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `?g` : ''}
+          SELECT DISTINCT ?childDecision ?childDecisionTypeLabel ?ckbLabel ?what ?eredienst ?eredienstLabel ${ENV.SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `?g` : ''}
           WHERE {
             ${fromEenheid ?
         `
@@ -177,7 +173,7 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
             ?ckb skos:prefLabel ?ckbLabel.
             ?besluitType skos:prefLabel ?besluitTypeLabel.
 
-            ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `GRAPH ?g {` : ''}
+            ${ENV.SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `GRAPH ?g {` : ''}
 
               ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
                 <http://purl.org/pav/createdBy> ?ckb;
@@ -197,11 +193,11 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
 
               ?childDecision a ?what.
 
-            ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `}` : ''}
+            ${ENV.SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `}` : ''}
           }
         }
 
-        ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `GRAPH ?g {` : ''}
+        ${ENV.SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `GRAPH ?g {` : ''}
 
           ?mostRecentParentSubmission prov:generated/dcterms:relation ?childDecision;
             <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#sentDate> ?dateSent;
@@ -214,11 +210,11 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
             FILTER(?otherDateSent > ?dateSent)
           }
 
-        ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `}` : ''}
+        ${ENV.SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `}` : ''}
 
         BIND(CONCAT(?ckbLabel, " namens ", ?eredienstLabel) as ?niceIngezondenDoor)
 
-        BIND(IRI(CONCAT("${WORSHIP_DECISIONS_BASE_URL}", STR(?submissionUuid))) as ?seeAlsoUrl)
+        BIND(IRI(CONCAT("${ENV.WORSHIP_DECISIONS_BASE_URL}", STR(?submissionUuid))) as ?seeAlsoUrl)
 
         BIND(STRBEFORE(STR(?dateSent), "T") AS ?niceDateSent)
         BIND(CONCAT(?childDecisionTypeLabel, " van ", ?eredienstLabel, " als laatste gebundeld en verstuurd door ", ?ckbLabel,
@@ -284,7 +280,7 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
 
         ?eredienst skos:prefLabel ?eredienstLabel.
 
-        ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `GRAPH ?g {` : ''}
+        ${ENV.SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `GRAPH ?g {` : ''}
 
           ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
             mu:uuid ?submissionUuid;
@@ -301,11 +297,11 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
               <http://mu.semte.ch/vocabularies/ext/sessionStartedAtTime> ?sessionStarted;
             dcterms:type ?besluitType.
 
-        ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `}` : ''}
+        ${ENV.SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `}` : ''}
 
         ?besluitType skos:prefLabel ?besluitTypeLabel.
 
-        BIND(IRI(CONCAT("${WORSHIP_DECISIONS_BASE_URL}", STR(?submissionUuid))) as ?seeAlsoUrl)
+        BIND(IRI(CONCAT("${ENV.WORSHIP_DECISIONS_BASE_URL}", STR(?submissionUuid))) as ?seeAlsoUrl)
 
         BIND(STRBEFORE(STR(?dateSent), "T") AS ?niceDateSent)
         BIND(STRBEFORE(STR(?sessionStarted), "T") AS ?niceSessionStarted)
@@ -370,7 +366,7 @@ export function prepareCKBSearchQuery({ fromEenheid, forEenheid, decisionType })
 
       ?besluitType skos:prefLabel ?besluitTypeLabel .
 
-      BIND(IRI(CONCAT("${WORSHIP_DECISIONS_BASE_URL}", STR(?submissionUuid))) as ?seeAlsoUrl)
+      BIND(IRI(CONCAT("${ENV.WORSHIP_DECISIONS_BASE_URL}", STR(?submissionUuid))) as ?seeAlsoUrl)
       BIND(STRBEFORE(STR(?dateSent), "T") AS ?niceDateSent)
       BIND(STRBEFORE(STR(?sessionStarted), "T") AS ?niceSessionStarted)
       BIND(CONCAT(?besluitTypeLabel, " verstuurd op ", ?niceDateSent, " voor zittingsdatum ", ?niceSessionStarted) as ?displayLabel)

--- a/query-utils.js
+++ b/query-utils.js
@@ -397,5 +397,5 @@ export async function isGemeente(eenheidUri) {
 
 
 export async function queryDatabase(queryStr) {
-  return query(queryStr, { sudo: true });
+  return query(queryStr, { sudo: ENV.USE_SUDO_QUERIES });
 }

--- a/query-utils.js
+++ b/query-utils.js
@@ -1,16 +1,15 @@
-import { querySudo } from '@lblod/mu-auth-sudo';
-import { sparqlEscapeUri } from 'mu';
+import { sparqlEscapeUri, query } from 'mu';
 import {
   crossReferenceMappingsGemeente_EB,
   crossReferenceMappingsGemeente_CKB_EB
 } from './config/cross-reference-mappings';
 
 const WORSHIP_DECISIONS_BASE_URL = process.env.WORSHIP_DECISIONS_BASE_URL
-      || "https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/";
+  || "https://databankerediensten.lokaalbestuur.vlaanderen.be/search/submissions/";
 
-const SCOPE_SUBMISSIONS_TO_ONE_GRAPH = process.env.SCOPE_SUBMISSIONS_TO_ONE_GRAPH == 'true' ? true : false ;
+const SCOPE_SUBMISSIONS_TO_ONE_GRAPH = process.env.SCOPE_SUBMISSIONS_TO_ONE_GRAPH == 'true' ? true : false;
 
-export async function bestuurseenheidForSession( sessionUri ) {
+export async function bestuurseenheidForSession(sessionUri) {
   const queryStr = `
 
      PREFIX besluit:  <http://data.vlaanderen.be/ns/besluit#>
@@ -26,9 +25,9 @@ export async function bestuurseenheidForSession( sessionUri ) {
      LIMIT 1
   `;
 
-  let result = await querySudo(queryStr);
+  let result = await query(queryStr, { sudo: true });
 
-  if(result.results.bindings.length == 1) {
+  if (result.results.bindings.length == 1) {
     return result.results.bindings[0].bestuurseenheid.value;
   }
   else {
@@ -36,7 +35,7 @@ export async function bestuurseenheidForSession( sessionUri ) {
   }
 }
 
-export async function getRelatedToActiveCKB( eenheidUri ) {
+export async function getRelatedToActiveCKB(eenheidUri) {
   const queryStr = `
     SELECT DISTINCT ?ckb WHERE {
       ?ckb <http://www.w3.org/ns/org#hasSubOrganization> ${sparqlEscapeUri(eenheidUri)};
@@ -44,11 +43,11 @@ export async function getRelatedToActiveCKB( eenheidUri ) {
         <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
     }
   `;
-  const result = (await querySudo(queryStr))?.results?.bindings || [];
+  const result = (await queryDatabase(queryStr))?.results?.bindings || [];
   return result[0] ? result[0].ckb.value : null;
 }
 
-export async function getEenheidForDecision( decisionUri ) {
+export async function getEenheidForDecision(decisionUri) {
   const queryStr = `
     PREFIX dcterms: <http://purl.org/dc/terms/>
 
@@ -58,11 +57,11 @@ export async function getEenheidForDecision( decisionUri ) {
     }
   `;
 
-  const result = (await querySudo(queryStr))?.results?.bindings || [];
+  const result = (await queryDatabase(queryStr))?.results?.bindings || [];
   return result[0] ? result[0].eenheid.value : null;
 }
 
-export function getRelatedDecisionType( decisionType, hasCKB ) {
+export function getRelatedDecisionType(decisionType, hasCKB) {
   // Mapping differs for some documents only if the bestuurseenheid has a CKB
   if (hasCKB) {
     return {
@@ -125,47 +124,47 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
       }
       WHERE {
         {
-          SELECT DISTINCT ?childDecision ?childDecisionTypeLabel ?ckbLabel ?what ?eredienst ?eredienstLabel ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `?g`: ''}
+          SELECT DISTINCT ?childDecision ?childDecisionTypeLabel ?ckbLabel ?what ?eredienst ?eredienstLabel ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `?g` : ''}
           WHERE {
             ${fromEenheid ?
-              `
+        `
                   VALUES ?eenheid {
                     ${sparqlEscapeUri(fromEenheid)}
                   }
               `: ''
-            }
+      }
 
             ${forEenheid ?
-              `
+        `
                   VALUES ?eredienst {
                     ${sparqlEscapeUri(forEenheid)}
                   }
               `: ''
-            }
+      }
 
             ${decisionTypeData.decisionType ?
-              `
+        `
                   VALUES ?besluitType {
                     ${sparqlEscapeUri(decisionTypeData.decisionType)}
                   }
                 `: ''
-            }
+      }
 
             ${forDecision ?
-              `
+        `
                   VALUES ?childDecision {
                     ${sparqlEscapeUri(forDecision)}
                   }
                 `: ''
-            }
+      }
 
             ${ckbUri ?
-              `
+        `
                   VALUES ?ckb {
                     ${sparqlEscapeUri(ckbUri)}
                   }
                 `: ''
-            }
+      }
 
             FILTER EXISTS {
               ?betrokkenBestuur <http://www.w3.org/ns/org#organization> ?eredienst.
@@ -178,7 +177,7 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
             ?ckb skos:prefLabel ?ckbLabel.
             ?besluitType skos:prefLabel ?besluitTypeLabel.
 
-            ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `GRAPH ?g {`: ''}
+            ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `GRAPH ?g {` : ''}
 
               ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
                 <http://purl.org/pav/createdBy> ?ckb;
@@ -198,11 +197,11 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
 
               ?childDecision a ?what.
 
-            ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `}`: ''}
+            ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `}` : ''}
           }
         }
 
-        ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `GRAPH ?g {`: ''}
+        ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `GRAPH ?g {` : ''}
 
           ?mostRecentParentSubmission prov:generated/dcterms:relation ?childDecision;
             <http://www.semanticdesktop.org/ontologies/2007/03/22/nmo#sentDate> ?dateSent;
@@ -215,7 +214,7 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
             FILTER(?otherDateSent > ?dateSent)
           }
 
-        ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `}`: ''}
+        ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `}` : ''}
 
         BIND(CONCAT(?ckbLabel, " namens ", ?eredienstLabel) as ?niceIngezondenDoor)
 
@@ -285,7 +284,7 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
 
         ?eredienst skos:prefLabel ?eredienstLabel.
 
-        ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `GRAPH ?g {`: ''}
+        ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `GRAPH ?g {` : ''}
 
           ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
             mu:uuid ?submissionUuid;
@@ -302,7 +301,7 @@ export function prepareQuery({ fromEenheid, forEenheid, ckbUri, decisionTypeData
               <http://mu.semte.ch/vocabularies/ext/sessionStartedAtTime> ?sessionStarted;
             dcterms:type ?besluitType.
 
-        ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `}`: ''}
+        ${SCOPE_SUBMISSIONS_TO_ONE_GRAPH ? `}` : ''}
 
         ?besluitType skos:prefLabel ?besluitTypeLabel.
 
@@ -385,7 +384,7 @@ export async function isCKB(eenheidUri) {
       ${sparqlEscapeUri(eenheidUri)} a <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst> .
     }`
 
-  return (await querySudo(queryStr)).boolean;
+  return (await queryDatabase(queryStr)).boolean;
 }
 
 export async function isGemeente(eenheidUri) {
@@ -397,5 +396,10 @@ export async function isGemeente(eenheidUri) {
       ${sparqlEscapeUri(eenheidUri)} besluit:classificatie|org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> .
     }`
 
-  return (await querySudo(queryStr)).boolean;
+  return (await queryDatabase(queryStr)).boolean;
+}
+
+
+export async function queryDatabase(queryStr) {
+  return query(queryStr, { sudo: true });
 }


### PR DESCRIPTION
### Overview
This PR introduces the following changes:
- Update `mu-javascript-template` to version 1.9.1
- Use the built-in `query` function (with the `sudo` option) instead of the `@lblod/mu-auth-sudo` package. This is technically a breaking change, because you'll need to set `ALLOW_MU_AUTH_SUDO` to `true` in the host-app.
- Use env-var to read out the environment variables in a seperate `env.js` file
- The main change: introduction of a `USE_SUDO_QUERIES` environment variable which controls whether queries are sent to the database with a sudo-header or not. Note: session queries will always be sent using a sudo header, regardless of this setting.

##### connected issues and PRs:
[DL-7170](https://binnenland.atlassian.net/browse/DL-7170)


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
