### PR TITLE
Fix crash when referred organisation has no active CKB

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,6 +60,9 @@ app.get('/search-documents', async function (req, res) {
           console.warn(`Skipping extra hop centraal bestuur. This should only be used in development mode.`);
           ckbUri = undefined;
         }
+      }
+
+      if (ckbUri) {
         const ckbType = await getOrganisationType(ckbUri);
         decisionType = await getReferredDecisionType(referrerDecisionType, referrerOrgType, ckbType);
       } else {


### PR DESCRIPTION
When getRelatedToActiveCKB returns null (erediensten without an active Centraal Bestuur, e.g. Protestantse kerken, or when BYPASS_HOP_CENTRAAL_BESTUUR is set), getOrganisationType was called with null, crashing with "Cannot read properties of null (reading 'replace')" at sparqlEscapeUri. SeeAlso: DL-7450