### PR TITLE
Fix document information endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -126,7 +126,8 @@ app.get('/document-information', async function (req, res) {
           ckbUri = null;
         }
 
-        referredOrgType = await getOrganisationType(ckbUri);
+        if (ckbUri)
+          referredOrgType = await getOrganisationType(ckbUri);
       }
 
       decisionType = await getReferredDecisionType(referrerDecisionType, referrerOrgType, referredOrgType);

--- a/app.js
+++ b/app.js
@@ -91,10 +91,12 @@ app.get('/document-information', async function (req, res) {
     const referrerDecisionType = req.query.forDecisionType;
     const forDecision = req.query.forRelatedDecision;
     const referredOrganisation = await getEenheidForDecision(forDecision);
-    const eenheid = await getEenheidForDecision(forDecision);
 
     const isLoggedInAsGemeente = await isGemeente(req.referrerOrganisation);
     const isSubmissionSentByCKB = await isDecisionTypeFromCKB(referrerDecisionType);
+
+    const referrerOrgType = await getOrganisationType(req.referrerOrganisation);
+    let referredOrgType = await getOrganisationType(referredOrganisation);
 
     let ckbUri;
     let decisionType;
@@ -117,15 +119,17 @@ app.get('/document-information', async function (req, res) {
 
       if (isCkbRelevant) {
         // Figure out whether the administrative unit is related to a CKB or is a CKB itself
-        ckbUri = await isCKB(eenheid) ? eenheid : await getRelatedToActiveCKB(eenheid);
+        ckbUri = await getRelatedToActiveCKB(referredOrganisation);
 
         if (BYPASS_HOP_CENTRAAL_BESTUUR) {
           console.warn(`Skipping extra hop centraal bestuur. This should only be used in development mode.`);
           ckbUri = null;
         }
+
+        referredOrgType = await getOrganisationType(ckbUri);
       }
 
-      decisionType = await getReferredDecisionType(referrerDecisionType, !!ckbUri);
+      decisionType = await getReferredDecisionType(referrerDecisionType, referrerOrgType, referredOrgType);
     }
 
     const query = prepareQuery(undefined, referredOrganisation, ckbUri, decisionType, forDecision);

--- a/app.js
+++ b/app.js
@@ -90,6 +90,7 @@ app.get('/document-information', async function (req, res) {
   try {
     const referrerDecisionType = req.query.forDecisionType;
     const forDecision = req.query.forRelatedDecision;
+    const referredOrganisation = await getEenheidForDecision(forDecision);
     const eenheid = await getEenheidForDecision(forDecision);
 
     const isLoggedInAsGemeente = await isGemeente(req.referrerOrganisation);
@@ -127,7 +128,7 @@ app.get('/document-information', async function (req, res) {
       decisionType = await getReferredDecisionType(referrerDecisionType, !!ckbUri);
     }
 
-    const query = prepareQuery(undefined, forDecision, ckbUri, decisionType);
+    const query = prepareQuery(undefined, referredOrganisation, ckbUri, decisionType, forDecision);
 
     // execute query
     // TODO: Here we could add a hook to connect to vendor-API if we need to.

--- a/query-utils.js
+++ b/query-utils.js
@@ -59,9 +59,9 @@ export async function getRelatedToActiveCKB( eenheidUri ) {
         a <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst> ;
         <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
     }
-  `;
+    LIMIT 1`;
   const result = (await querySudo(queryStr))?.results?.bindings || [];
-  return result[0] ? result[0].ckb.value : null;
+  return result[0]?.ckb?.value;
 }
 
 export async function getEenheidForDecision( decisionUri ) {
@@ -73,10 +73,11 @@ export async function getEenheidForDecision( decisionUri ) {
       ?submission
         dcterms:subject ${sparqlEscapeUri(decisionUri)} ;
         pav:createdBy ?eenheid .
-    }`;
+    }
+    LIMIT 1`;
 
   const result = (await querySudo(queryStr))?.results?.bindings || [];
-  return result[0] ? result[0].eenheid.value : null;
+  return result[0]?.eenheid?.value;
 }
 
 export async function getReferredDecisionType(referrerDecisionType, referrerOrgType, referredOrgType) {


### PR DESCRIPTION
**[DL-7464]**

There seemed to be some issues with the `/document-information` endpoint. These are the fixes.

Main issue: the arguments to the `prepareQuery` function where wrong. In the wrong order, and it was supplying a boolean when a URI was needed. This resulted in an error. This has been rectified, and some more information was gathered about the referer and referee to make the decisionType check more accurate.